### PR TITLE
0.2.0/create terraform resources

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+
+
+## Description & motivation
+
+## Checklist
+- [ ] My pull request represents one story (logical piece of work).
+- [ ] I have updated the version in `setup.py`.
+- [ ] I have re-read the descriptions at the top of every changed python file and ensured that the description is up to date.
+- [ ] I have added comments throughout my project that allow an understanding of what the code does without the need to read the code itself.
+- [ ] I have re-read the `README` and updated relevant sections that pertain to this PR.
+- [ ] My package has no residual code that is no longer used.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,16 @@
-
-
 ## Description & motivation
+JIRA issue:
+
+## Detailed changes
+
+added
+* .
+
+changed
+* .
+
+removed
+* .
 
 ## Checklist
 - [ ] My pull request represents one story (logical piece of work).

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-.venv*
 *.egg-info*
 .env*
+.venv*
 __pycache__/
 target/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.egg-info*
 .env*
 __pycache__/
+target/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ SNOWFLAKE_SCHEMA="<value>"
 SNOWFLAKE_ROLE="<value>"
 ```
 
+## Recommended `.gitignore`
+```.gitignore
+*.egg-info*
+.env*
+.venv*
+__pycache__/
+target/
+```
+
+## Run
+To run the code, run
+```bash
+python snowglober/main.py
+```
 ## Unit tests
 To test the code, run
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='snowglober',
-    version='0.1.0',
+    version='0.2.0',
     author='Amir Jaber',
     author_email='amir@rittmananalytics.com',
     install_requires=[

--- a/snowglober/generate_tf_config.py
+++ b/snowglober/generate_tf_config.py
@@ -45,11 +45,7 @@ class TerraformConfigGenerator:
             resources.append(resource)
         return resources
 
-    # TODO: Implement more methods like _generate_warehouse_config for other resource types
-    # def _generate_user_config(self):
-    #     ...
-
-    def write_config_to_file(self):
+    def write_configs_to_files(self):
         # Create target directory if it doesn't exist
         os.makedirs('target', exist_ok=True)
 

--- a/snowglober/generate_tf_config.py
+++ b/snowglober/generate_tf_config.py
@@ -5,7 +5,7 @@ class TerraformConfigGenerator:
     def __init__(self, connector):
         self.connector = connector
 
-    def _generate_database_config(self):
+    def _generate_databases_config(self):
         databases = self.connector.get_all_databases()
         resources = []
 
@@ -22,7 +22,23 @@ class TerraformConfigGenerator:
             resources.append(resource)
         return resources
 
-    def _generate_warehouse_config(self):
+    def _generate_roles_config(self):
+        roles = self.connector.get_all_roles()
+        resources = []
+
+        for role in roles:
+            resource = {
+                "type": "snowflake_role",
+                "name": role['name'],
+                "properties": {
+                    "name": role['name'],
+                    "comment": role['comment']
+                }
+            }
+            resources.append(resource)
+        return resources
+
+    def _generate_warehouses_config(self):
         warehouses = self.connector.get_all_warehouses()
         resources = []
 
@@ -51,8 +67,9 @@ class TerraformConfigGenerator:
 
         # List of resource types and corresponding config generation methods
         resources_to_generate = [
-            {"resource_type": "databases", "generation_method": self._generate_database_config},
-            {"resource_type": "warehouses", "generation_method": self._generate_warehouse_config},
+            {"resource_type": "databases", "generation_method": self._generate_databases_config},
+            {"resource_type": "roles", "generation_method": self._generate_roles_config},
+            {"resource_type": "warehouses", "generation_method": self._generate_warehouses_config},
         ]
 
         # Generate config for each resource type and write to file

--- a/snowglober/generate_tf_config.py
+++ b/snowglober/generate_tf_config.py
@@ -1,0 +1,41 @@
+import json
+import os
+
+class TerraformConfigGenerator:
+    def __init__(self, connector):
+        self.connector = connector
+
+    def _generate_config(self):
+        warehouses = self.connector.get_all_warehouses()
+        resources = []
+
+        for warehouse in warehouses:
+            resource = {
+                "type": "snowflake_warehouse",
+                "name": warehouse['name'],
+                "properties": {
+                    "name": warehouse['name'],
+                    "comment": warehouse['comment'],
+                    "warehouse_size": warehouse['size'],
+                    "auto_suspend_minutes": warehouse['auto_suspend'],
+                    "auto_resume": warehouse['auto_resume'].lower(),
+                    "initially_suspended": warehouse['state'].upper() == 'SUSPENDED',
+                    "scaling_policy": warehouse['scaling_policy'],
+                    "min_cluster_count": warehouse['min_cluster_count'],
+                    "max_cluster_count": warehouse['max_cluster_count']
+                }
+            }
+            resources.append(resource)
+        return {"resource": resources}
+
+    def generate(self):
+        config = self._generate_config()
+
+        os.makedirs('target', exist_ok=True)
+
+        with open('target/warehouse.tf', 'w') as f:
+            for resource in config["resource"]:
+                f.write("resource \"{}\" \"{}\" {{\n".format(resource["type"], resource["name"]))
+                for property, value in resource["properties"].items():
+                    f.write("    {} = \"{}\"\n".format(property, value))
+                f.write("}\n\n")

--- a/snowglober/generate_tf_config.py
+++ b/snowglober/generate_tf_config.py
@@ -5,6 +5,23 @@ class TerraformConfigGenerator:
     def __init__(self, connector):
         self.connector = connector
 
+    def _generate_database_config(self):
+        databases = self.connector.get_all_databases()
+        resources = []
+
+        for database in databases:
+            resource = {
+                "type": "snowflake_database",
+                "name": database['name'],
+                "properties": {
+                    "name": database['name'],
+                    "comment": database['comment'],
+                    "data_retention_time_in_days": database['retention_time']
+                }
+            }
+            resources.append(resource)
+        return resources
+
     def _generate_warehouse_config(self):
         warehouses = self.connector.get_all_warehouses()
         resources = []
@@ -38,9 +55,8 @@ class TerraformConfigGenerator:
 
         # List of resource types and corresponding config generation methods
         resources_to_generate = [
-            {"resource_type": "warehouse", "generation_method": self._generate_warehouse_config},
-            # Add more dictionary entries for other resource types like so:
-            # {"resource_type": "user", "generation_method": self._generate_user_config},
+            {"resource_type": "databases", "generation_method": self._generate_database_config},
+            {"resource_type": "warehouses", "generation_method": self._generate_warehouse_config},
         ]
 
         # Generate config for each resource type and write to file

--- a/snowglober/generate_tf_config.py
+++ b/snowglober/generate_tf_config.py
@@ -5,7 +5,7 @@ class TerraformConfigGenerator:
     def __init__(self, connector):
         self.connector = connector
 
-    def _generate_config(self):
+    def _generate_warehouse_config(self):
         warehouses = self.connector.get_all_warehouses()
         resources = []
 
@@ -26,16 +26,29 @@ class TerraformConfigGenerator:
                 }
             }
             resources.append(resource)
-        return {"resource": resources}
+        return resources
 
-    def generate(self):
-        config = self._generate_config()
+    # TODO: Implement more methods like _generate_warehouse_config for other resource types
+    # def _generate_user_config(self):
+    #     ...
 
+    def write_config_to_file(self):
+        # Create target directory if it doesn't exist
         os.makedirs('target', exist_ok=True)
 
-        with open('target/warehouse.tf', 'w') as f:
-            for resource in config["resource"]:
-                f.write("resource \"{}\" \"{}\" {{\n".format(resource["type"], resource["name"]))
-                for property, value in resource["properties"].items():
-                    f.write("    {} = \"{}\"\n".format(property, value))
-                f.write("}\n\n")
+        # List of resource types and corresponding config generation methods
+        resources_to_generate = [
+            {"resource_type": "warehouse", "generation_method": self._generate_warehouse_config},
+            # Add more dictionary entries for other resource types like so:
+            # {"resource_type": "user", "generation_method": self._generate_user_config},
+        ]
+
+        # Generate config for each resource type and write to file
+        for resource_info in resources_to_generate:
+            config = resource_info["generation_method"]()
+            with open(f'target/{resource_info["resource_type"]}.tf', 'w') as f:
+                for resource in config:
+                    f.write("resource \"{}\" \"{}\" {{\n".format(resource["type"], resource["name"]))
+                    for property, value in resource["properties"].items():
+                        f.write("    {} = \"{}\"\n".format(property, value))
+                    f.write("}\n\n")

--- a/snowglober/generate_tf_config.py
+++ b/snowglober/generate_tf_config.py
@@ -38,6 +38,38 @@ class TerraformConfigGenerator:
             resources.append(resource)
         return resources
 
+    def _generate_users_config(self):
+        users = self.connector.get_all_users()
+        resources = []
+
+        for user in users:
+            resource = {
+                "type": "snowflake_user",
+                "name": user['name'],
+                "properties": {
+                    "name": user['name'],
+                    "login_name": user['login_name'],
+                    "comment": user['comment'],
+                    "disabled": user['disabled'].lower(),
+                    "display_name": user['display_name'],
+                    "email": user['email'],
+                    "first_name": user['first_name'],
+                    "last_name": user['last_name'],
+                    "default_warehouse": user['default_warehouse'],
+                    "default_role": user['default_role'],
+                    "must_change_password": user['must_change_password'].lower(),
+                }
+            }
+            # If optional fields 'default_namespace' and 'default_secondary_roles' are present, add them to properties
+            if user['default_namespace']:
+                resource["properties"]["default_namespace"] = user['default_namespace']
+            if user['default_secondary_roles']:
+                resource["properties"]["default_secondary_roles"] = user['default_secondary_roles']
+
+            resources.append(resource)
+        return resources
+
+
     def _generate_warehouses_config(self):
         warehouses = self.connector.get_all_warehouses()
         resources = []
@@ -69,6 +101,7 @@ class TerraformConfigGenerator:
         resources_to_generate = [
             {"resource_type": "databases", "generation_method": self._generate_databases_config},
             {"resource_type": "roles", "generation_method": self._generate_roles_config},
+            {"resource_type": "users", "generation_method": self._generate_users_config},
             {"resource_type": "warehouses", "generation_method": self._generate_warehouses_config},
         ]
 

--- a/snowglober/main.py
+++ b/snowglober/main.py
@@ -1,0 +1,14 @@
+# bootstrapping file; the orchestrator of the application
+
+from snowglober.snowflake_connector import SnowflakeConnector
+from generate_tf_config import TerraformConfigGenerator
+
+def main():
+    connector = SnowflakeConnector()
+    generator = TerraformConfigGenerator(connector)
+    generator.generate()
+
+if __name__ == "__main__":
+    main()
+
+

--- a/snowglober/main.py
+++ b/snowglober/main.py
@@ -6,7 +6,7 @@ from generate_tf_config import TerraformConfigGenerator
 def main():
     connector = SnowflakeConnector()
     generator = TerraformConfigGenerator(connector)
-    generator.generate()
+    generator.write_config_to_file()
 
 if __name__ == "__main__":
     main()

--- a/snowglober/main.py
+++ b/snowglober/main.py
@@ -6,7 +6,7 @@ from generate_tf_config import TerraformConfigGenerator
 def main():
     connector = SnowflakeConnector()
     generator = TerraformConfigGenerator(connector)
-    generator.write_config_to_file()
+    generator.write_configs_to_files()
 
 if __name__ == "__main__":
     main()

--- a/snowglober/snowflake_connector.py
+++ b/snowglober/snowflake_connector.py
@@ -39,6 +39,10 @@ class SnowflakeConnector:
     def get_all_databases(self):
         query = "show databases"
         return self._execute_query(query)
+    
+    def get_all_roles(self):
+        query = "show roles"
+        return self._execute_query(query)
 
     def get_all_users(self):
         query = "show users"
@@ -46,8 +50,4 @@ class SnowflakeConnector:
 
     def get_all_warehouses(self):
         query = "show warehouses"
-        return self._execute_query(query)
-    
-    def get_all_roles(self):
-        query = "show roles"
         return self._execute_query(query)


### PR DESCRIPTION
## Description & motivation
Issue: https://rittmananalytics.atlassian.net/browse/TS-8

This update adds **resource** generation. The package now generates one `.tf` file per **resource type**, with one `resource` for each object. 

Currently this is only done for 4 resources types, while working towards an end-to-end POC:
* databases
* roles
* uses
* warehouses

<img width="330" alt="image" src="https://github.com/rittmananalytics/snowglober/assets/38318312/82bdd05e-3d1d-4c25-ac59-5d13496b5707">

Eventually this will be expanded to all snowflake resource types

## Detailed changes

core
* created bootstrapping `snowglober/main.py` module, which calls classes, methods and functions in the correct order.
* created `snowglober/generate_tf_config.py`
  * takes the output from `snowflake_connector.py`, which details all **objects** for each **resource type** which exist in snowflake
  * generates `.tf` files with resources for each **object**

other
* added pr template
* README
  * added **run instructions**
  * added suggested `.gitignore`

## The next PR
generate basic non-resource .tf code:
* `terraform` (`required_providers`)
* `provider`
<img width="354" alt="image" src="https://github.com/rittmananalytics/snowglober/assets/38318312/7c4519f2-305e-4cb2-a1e1-3048665d1cee">


## Checklist
- [X] My pull request represents one story (logical piece of work).
- [X] I have updated the version in `setup.py`.
- [ ] I have re-read the descriptions at the top of every changed python file and ensured that the description is up to date.
- [ ] I have added comments throughout my project that allow an understanding of what the code does without the need to read the code itself.
- [X] I have re-read the `README` and updated relevant sections that pertain to this PR.
- [X] My package has no residual code that is no longer used.