### PR TITLE
0.3.0/create non resource .tf code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .venv*
 __pycache__/
 target/
+.terraform*

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ SNOWFLAKE_ROLE="<value>"
 .env*
 .venv*
 __pycache__/
-target/
+terraform.tfvars
+.terraform*
 ```
 
 ## Run

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ Inspired by the Medium article [Terraforming Snowflake (the Easy Way)](https://m
 This package is a WORK IN PROGRESS. It aims to automate migration of Snowflake instances to Terraform by performing the following tasks:
 1. extract all **objects** in **Snowflake** which map to a **Terraform** `resource`.
 2. create terraform files with resources made to map to each live object.
+# Usage
+## environment variables in `.tfvars` 
+Snowglober automates the creation of the `terraform.tfvars` file, which is used by Terraform for variable definitions. It generates this file using your existing environment variables. If a variable already exists in `terraform.tfvars`, Snowglober will not overwrite it.
+
+
+1. Ensure your environment variables match (case-insensitively) with the variables listed in the project's [Environment Variables](#environment-variables) section.
+
+2. Run Snowglober. It creates the `terraform.tfvars` file based on your environment variables.
+
+3. Run your usual Terraform commands. The `terraform.tfvars` file is automatically included in these commands, for example, when you run `terraform apply`.
+
 
 # Dev
 This package is open source in nature, under the MIT license. Anyone who wants to contribute is free to do so, just reach out!

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install -e /path/to/snowglober/
 
 `.env` file at top of repo:
 ```bash
-SNOWFLAKE_USER="<value>"
+SNOWFLAKE_USERNAME="<value>"
 SNOWFLAKE_PASSWORD="<value>"
 SNOWFLAKE_ACCOUNT="<value>"
 SNOWFLAKE_WAREHOUSE="<value>"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='snowglober',
-    version='0.2.0',
+    version='0.3.0',
     author='Amir Jaber',
     author_email='amir@rittmananalytics.com',
     install_requires=[

--- a/snowglober/generate_tf_config.py
+++ b/snowglober/generate_tf_config.py
@@ -6,7 +6,28 @@ class TerraformConfigGenerator:
     def __init__(self, connector):
         self.connector = connector
 
-    def generate_providers_config_file(self):
+    def generate_variables_tf_file(self):
+        print("Generating variables.tf...")
+        variables = [
+            "snowflake_account",
+            "snowflake_role",
+            "snowflake_warehouse",
+            "snowflake_username",
+            "snowflake_password",
+        ]
+        
+        # Generate config string
+        config_lines = []
+        for variable in variables:
+            config_lines.append(f"variable \"{variable}\" {{}}")
+            
+        config = "\n".join(config_lines)
+        
+        # Write to file
+        with open('target/variables.tf', 'w') as f:
+            f.write(config)
+
+    def generate_providers_tf_file(self):
         print("Generating providers.tf...")
         config = textwrap.dedent("""\
         terraform {
@@ -166,7 +187,7 @@ class TerraformConfigGenerator:
             resources.append(resource)
         return resources
 
-    def write_resource_configs_to_files(self):
+    def write_resource_configs_to_tf_files(self):
         # Create target directory if it doesn't exist
         os.makedirs('target', exist_ok=True)
 

--- a/snowglober/generate_tf_config.py
+++ b/snowglober/generate_tf_config.py
@@ -6,6 +6,9 @@ class TerraformConfigGenerator:
     def __init__(self, connector):
         self.connector = connector
 
+        # Create target directory if it doesn't exist
+        os.makedirs('target', exist_ok=True)
+
     def generate_variables_tf_file(self):
         print("Generating variables.tf...")
         variables = [
@@ -188,8 +191,6 @@ class TerraformConfigGenerator:
         return resources
 
     def write_resource_configs_to_tf_files(self):
-        # Create target directory if it doesn't exist
-        os.makedirs('target', exist_ok=True)
 
         # List of resource types and corresponding config generation methods
         resources_to_generate = [

--- a/snowglober/generate_tf_config.py
+++ b/snowglober/generate_tf_config.py
@@ -176,12 +176,12 @@ class TerraformConfigGenerator:
                     "name": warehouse['name'],
                     "comment": warehouse['comment'],
                     "warehouse_size": warehouse['size'],
-                    "auto_suspend_minutes": warehouse['auto_suspend'],
-                    "auto_resume": warehouse['auto_resume'].lower(),
-                    "initially_suspended": warehouse['state'].upper() == 'SUSPENDED',
-                    "scaling_policy": warehouse['scaling_policy'],
-                    "min_cluster_count": warehouse['min_cluster_count'],
-                    "max_cluster_count": warehouse['max_cluster_count']
+                    "auto_suspend": int(warehouse['auto_suspend']),
+                    "auto_resume": str(warehouse['auto_resume'].lower() == 'true').lower(),
+                "initially_suspended": str(warehouse['state'].upper() == 'SUSPENDED').lower(),
+                "scaling_policy": warehouse['scaling_policy'],
+                "min_cluster_count": int(warehouse['min_cluster_count']),
+                "max_cluster_count": int(warehouse['max_cluster_count'])
                 }
             }
             resources.append(resource)

--- a/snowglober/main.py
+++ b/snowglober/main.py
@@ -6,9 +6,11 @@ from generate_tf_config import TerraformConfigGenerator
 def main():
     connector = SnowflakeConnector()
     generator = TerraformConfigGenerator(connector)
-    generator.write_configs_to_files()
+    generator._generate_providers_config()
+    generator.write_resource_configs_to_files()
 
 if __name__ == "__main__":
     main()
+    print("Snowglober has successfully finished generating Terraform configs!")
 
 

--- a/snowglober/main.py
+++ b/snowglober/main.py
@@ -6,7 +6,8 @@ from generate_tf_config import TerraformConfigGenerator
 def main():
     connector = SnowflakeConnector()
     generator = TerraformConfigGenerator(connector)
-    generator._generate_providers_config()
+    generator.generate_providers_config_file()
+    generator.add_missing_environment_variables_to_tfvars_file()
     generator.write_resource_configs_to_files()
 
 if __name__ == "__main__":

--- a/snowglober/main.py
+++ b/snowglober/main.py
@@ -6,9 +6,10 @@ from generate_tf_config import TerraformConfigGenerator
 def main():
     connector = SnowflakeConnector()
     generator = TerraformConfigGenerator(connector)
-    generator.generate_providers_config_file()
+    generator.generate_variables_tf_file()
+    generator.generate_providers_tf_file()
     generator.add_missing_environment_variables_to_tfvars_file()
-    generator.write_resource_configs_to_files()
+    generator.write_resource_configs_to_tf_files()
 
 if __name__ == "__main__":
     main()

--- a/snowglober/snowflake_connector.py
+++ b/snowglober/snowflake_connector.py
@@ -7,7 +7,7 @@ class SnowflakeConnector:
 
     def __init__(self):
         load_dotenv()
-        self.user = os.getenv('SNOWFLAKE_USER')
+        self.user = os.getenv('SNOWFLAKE_USERNAME')
         self.password = os.getenv('SNOWFLAKE_PASSWORD')
         self.account = os.getenv('SNOWFLAKE_ACCOUNT')
         self.warehouse = os.getenv('SNOWFLAKE_WAREHOUSE')


### PR DESCRIPTION
## Description & motivation
JIRA issue: https://rittmananalytics.atlassian.net/browse/TS-9

This adds generation of the remaining` .tf `files that are needed to establish a connection and run `terraform plan`:
* `providers.tf`
* `terraform.tfvars` (generated from environment variables)
* `variables.tf`

Now you can get to `terraform plan` with existing resources in 30 seconds:
<img width="966" alt="image" src="https://github.com/rittmananalytics/snowglober/assets/38318312/7ad5b9bf-735f-455a-bbf3-56091d3878ff">

## Detailed changes

added
* methods to class `TerraformConfigGenerator` in order to accomplish this

changed
* added print statements for clarity
* renamed methods for readability

## Next PR: run `terraform import` for each **resource** programmatically
https://rittmananalytics.atlassian.net/browse/TS-12

## Checklist
- [X] My pull request represents one story (logical piece of work).
- [X] I have updated the version in `setup.py`.
- [ ] I have re-read the descriptions at the top of every changed python file and ensured that the description is up to date.
- [X] I have added comments throughout my project that allow an understanding of what the code does without the need to read the code itself.
- [X] I have re-read the `README` and updated relevant sections that pertain to this PR.
- [X] My package has no residual code that is no longer used.