### PR TITLE
run terraform import for each resource programmatically

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ removed
 ## Checklist
 - [ ] My pull request represents one story (logical piece of work).
 - [ ] I have updated the version in `setup.py`.
-- [ ] I have re-read the descriptions at the top of every changed python file and ensured that the description is up to date.
+- [X] I have re-read all `docstrings` and other documentation affected by my changes and ensured they are accurate.
 - [ ] I have added comments throughout my project that allow an understanding of what the code does without the need to read the code itself.
 - [ ] I have re-read the `README` and updated relevant sections that pertain to this PR.
 - [ ] My package has no residual code that is no longer used.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ removed
 ## Checklist
 - [ ] My pull request represents one story (logical piece of work).
 - [ ] I have updated the version in `setup.py`.
-- [X] I have re-read all `docstrings` and other documentation affected by my changes and ensured they are accurate.
+- [ ] I have re-read all `docstrings` and other documentation affected by my changes and ensured they are accurate.
 - [ ] I have added comments throughout my project that allow an understanding of what the code does without the need to read the code itself.
 - [ ] I have re-read the `README` and updated relevant sections that pertain to this PR.
 - [ ] My package has no residual code that is no longer used.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ snowglober's `.tf` file generation workflow
 1. set up `provider` and `variable` files; **variables** contain **creds** and are populated from `.env` vars
 1. query **snowflake** for all objects of each **resource type**
 1. generate `.tf` files with **resources** - at this stage only required properties are defined
+1. run `terraform init`
 1. run `terraform import` for each resource
 1. extract remaining (and optional) properties from the generated `.tfstate` file
 1. update the **resources** in the `.tf` files with the remaining properties

--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ Snowglober automates the creation of the `terraform.tfvars` file, which is used 
 
 3. Run your usual Terraform commands. The `terraform.tfvars` file is automatically included in these commands, for example, when you run `terraform apply`.
 
-
+# Architecture
+snowglober's `.tf` file generation workflow
+1. set up `provider` and `variable` files; **variables** contain **creds** and are populated from `.env` vars
+1. query **snowflake** for all objects of each **resource type**
+1. generate `.tf` files with **resources** - at this stage only required properties are defined
+1. run `terraform import` for each resource
+1. extract remaining (and optional) properties from the generated `.tfstate` file
+1. update the **resources** in the `.tf` files with the remaining properties
 # Dev
 This package is open source in nature, under the MIT license. Anyone who wants to contribute is free to do so, just reach out!
 ## Install in dev mode

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='snowglober',
-    version='0.3.0',
+    version='0.4.0',
     author='Amir Jaber',
     author_email='amir@rittmananalytics.com',
     install_requires=[

--- a/snowglober/generate_tf_config.py
+++ b/snowglober/generate_tf_config.py
@@ -233,6 +233,13 @@ class TerraformConfigGenerator:
                     f.write("}\n\n")
             print(f'Generating config for {resource_info["resource_type"]} at target/{resource_info["resource_type"]}.tf...done')
 
+    def run_terraform_init(self):
+
+        # Run terraform init
+        print("Running terraform init...")
+        subprocess.run(["terraform", "-chdir=target", "init"], check=True)
+        print("Running terraform init...done")
+
     def import_resources(self):
         # Delete existing .tfstate file if it exists
         tfstate_file_path = 'target/terraform.tfstate'

--- a/snowglober/generate_tf_config.py
+++ b/snowglober/generate_tf_config.py
@@ -5,9 +5,16 @@ import subprocess
 import textwrap
 
 class TerraformConfigGenerator:
+
     def __init__(self, connector):
         self.connector = connector
         self.resource_mapping = {}  # This will hold the mapping between Terraform resource names and cloud IDs
+
+        # Define common file paths
+        self.tfstate_file_path = 'target/terraform.tfstate'
+        self.tfvars_file_path = 'target/terraform.tfvars'
+        self.tf_variables_file_path = 'target/variables.tf'
+        self.tf_providers_file_path = 'target/providers.tf'
 
         # Create target directory if it doesn't exist
         os.makedirs('target', exist_ok=True)
@@ -74,7 +81,7 @@ class TerraformConfigGenerator:
         config = "\n".join(config_lines)
         
         # Write to file
-        with open('target/variables.tf', 'w') as f:
+        with open(self.tf_variables_file_path, 'w') as f:
             f.write(config)
 
         print("Generating variables.tf...done")
@@ -101,7 +108,7 @@ class TerraformConfigGenerator:
         }
         """)
 
-        with open('target/providers.tf', 'w') as f:
+        with open(self.tf_providers_file_path, 'w') as f:
             f.write(config)
 
         print("Generating providers.tf...done")
@@ -126,8 +133,8 @@ class TerraformConfigGenerator:
         existing_vars = {}
         
         # Read existing terraform.tfvars file
-        if os.path.exists('target/terraform.tfvars'):
-            with open('target/terraform.tfvars', 'r') as f:
+        if os.path.exists(self.tfvars_file_path):
+            with open(self.tfvars_file_path, 'r') as f:
                 lines = f.readlines()
                 for line in lines:
                     line = line.strip()
@@ -150,7 +157,7 @@ class TerraformConfigGenerator:
         config = "\n".join(config_lines)
 
         # Append to file
-        with open('target/terraform.tfvars', 'a') as f:
+        with open(self.tfvars_file_path, 'a') as f:
             f.write("\n" + config)
 
     def _generate_resource_config_for_all_databases(self):
@@ -236,10 +243,9 @@ class TerraformConfigGenerator:
     def import_resources(self):
 
         # Delete existing .tfstate file if it exists
-        tfstate_file_path = 'target/terraform.tfstate'
-        if os.path.exists(tfstate_file_path):
-            os.remove(tfstate_file_path)
-            print(f"Deleted existing {tfstate_file_path} file.")
+        if os.path.exists(self.tfstate_file_path):
+            os.remove(self.tfstate_file_path)
+            print(f"Deleted existing {self.tfstate_file_path} file.")
 
         # Import resources into Terraform state
         print("Importing resources into Terraform state...")
@@ -250,15 +256,14 @@ class TerraformConfigGenerator:
     def update_tf_files_with_optional_properties(self):
 
         # Check if .tfstate file exists
-        tfstate_file_path = 'target/terraform.tfstate'
-        if not os.path.exists(tfstate_file_path):
+        if not os.path.exists(self.tfstate_file_path):
             print("No .tfstate file found. Run 'import_resources' first.")
             return
 
         print("Updating .tf files with optional properties...")
 
         # Load .tfstate file
-        with open(tfstate_file_path, 'r') as f:
+        with open(self.tfstate_file_path, 'r') as f:
             tfstate_content = json.load(f)
 
         # Loop through each resource type

--- a/snowglober/generate_tf_config.py
+++ b/snowglober/generate_tf_config.py
@@ -26,29 +26,32 @@ class TerraformConfigGenerator:
             "snowflake_database": {
                 "required_properties": ["name"],
                 "optional_properties": ["comment", "data_retention_time_in_days", "from_database", 
-                                        "from_replica", "from_share", "is_transient", "replication_configuration",],
-                "ignore_names": [],
+                                        "from_replica", "from_share", "is_transient", "replication_configuration",
+                                        "from_database", "is_transient",],
+                "names_to_ignore": [],
             },
             "snowflake_role": {
                 "required_properties": ["name",],
                 "optional_properties": ["comment",],
-                "ignore_names": [],
+                "names_to_ignore": [],
             },
             "snowflake_user": {
                 "required_properties": ["name", "login_name"],
                 "optional_properties": ["comment", "default_namespace", "default_role", "default_secondary_roles", 
                                         "default_warehouse", "disabled", "display_name", "email", 
                                         "first_name", "last_name", "must_change_password", 
-                                        "password", "rsa_public_key", "rsa_public_key_2",],
-                "ignore_names": ["SNOWFLAKE"],
+                                        "password", "rsa_public_key", "rsa_public_key_2", "tag",],
+                "names_to_ignore": ["SNOWFLAKE"],
             },
             "snowflake_warehouse": {
                 "required_properties": ["name",],
                 "optional_properties": ["auto_resume", "auto_suspend", "comment", "initially_suspended", 
                                         "max_cluster_count", "max_concurrency_level", "min_cluster_count", 
                                         "resource_monitor", "scaling_policy", "statement_queued_timeout_in_seconds", 
-                                        "statement_timeout_in_seconds", "wait_for_provisioning", "warehouse_size",],
-                "ignore_names": [],
+                                        "statement_timeout_in_seconds", "wait_for_provisioning", "warehouse_size",
+                                        "enable_query_acceleration", "query_acceleration_max_scale_factor",
+                                        "warehouse_type",],
+                "names_to_ignore": [],
             }
         }
 
@@ -184,8 +187,8 @@ class TerraformConfigGenerator:
 
         for resource in all_resources:
 
-            # Don't generate config for any resource in ignore_names
-            if resource['name'].upper() in map(str.upper, self.valid_properties[resource_type]["ignore_names"]):
+            # Don't generate config for any resource in names_to_ignore
+            if resource['name'].upper() in map(str.upper, self.valid_properties[resource_type]["names_to_ignore"]):
                 continue
 
             config_resource = {

--- a/snowglober/generate_tf_config.py
+++ b/snowglober/generate_tf_config.py
@@ -134,7 +134,13 @@ class TerraformConfigGenerator:
                     "name": database['name'],
                 }
             }
+
             resources.append(resource)
+
+            # Add to resource mapping for terraform import
+            tf_resource_name = f"{resource['type']}.{resource['name']}"
+            self.resource_mapping[tf_resource_name] = database['name']  # Assuming the 'name' property of database is the cloud ID
+
         return resources
 
     def _generate_resource_config_for_all_roles(self):
@@ -153,7 +159,13 @@ class TerraformConfigGenerator:
                     "name": role['name'],
                 }
             }
+
             resources.append(resource)
+        
+            # Add to resource mapping for terraform import
+            tf_resource_name = f"{resource['type']}.{resource['name']}"
+            self.resource_mapping[tf_resource_name] = role['name']  # Assuming the 'name' property of role is the cloud ID
+
         return resources
 
     def _generate_resource_config_for_all_users(self):
@@ -205,7 +217,13 @@ class TerraformConfigGenerator:
                     "name": warehouse['name'],
                 }
             }
+
             resources.append(resource)
+        
+            # Add to resource mapping for terraform import
+            tf_resource_name = f"{resource['type']}.{resource['name']}"
+            self.resource_mapping[tf_resource_name] = warehouse['name']  # Assuming the 'name' property of warehouse is the cloud ID
+
         return resources
 
     def write_resource_configs_to_tf_files(self):
@@ -255,6 +273,19 @@ class TerraformConfigGenerator:
                 "default_secondary_roles", "default_warehouse", "disabled",
                 "display_name", "email", "first_name", "last_name", "login_name",
                 "must_change_password", "password", "rsa_public_key", "rsa_public_key_2"
+            ],
+            "snowflake_database": [
+                "name", "comment", "data_retention_time_in_days", "from_database", "from_replica", 
+                "from_share", "is_transient", "replication_configuration"
+            ],
+            "snowflake_role": [
+                "name", "comment"
+            ],
+            "snowflake_warehouse": [
+                "name", "auto_resume", "auto_suspend", "comment", "initially_suspended", 
+                "max_cluster_count", "max_concurrency_level", "min_cluster_count", "resource_monitor", 
+                "scaling_policy", "statement_queued_timeout_in_seconds", "statement_timeout_in_seconds", 
+                "wait_for_provisioning", "warehouse_size"
             ]
         }
 

--- a/snowglober/generate_tf_config.py
+++ b/snowglober/generate_tf_config.py
@@ -25,11 +25,12 @@ class TerraformConfigGenerator:
 
         # Define resources_to_generate as an instance attribute
         self.resources_to_generate = [
-            {"resource_type": "snowflake_database", "api_call": self.connector.get_all_databases},
-            {"resource_type": "snowflake_role", "api_call": self.connector.get_all_roles},
-            {"resource_type": "snowflake_user", "api_call": self.connector.get_all_users},
-            {"resource_type": "snowflake_warehouse", "api_call": self.connector.get_all_warehouses}
+            {"resource_type": "snowflake_database", "api_call": lambda: self.connector.get_all_objects_of_a_resource_type('databases')},
+            {"resource_type": "snowflake_role", "api_call": lambda: self.connector.get_all_objects_of_a_resource_type('roles')},
+            {"resource_type": "snowflake_user", "api_call": lambda: self.connector.get_all_objects_of_a_resource_type('users')},
+            {"resource_type": "snowflake_warehouse", "api_call": lambda: self.connector.get_all_objects_of_a_resource_type('warehouses')}
         ]
+
 
 
         # Define valid_properties for each resource type TODO RENAME DICT?

--- a/snowglober/generate_tf_config.py
+++ b/snowglober/generate_tf_config.py
@@ -12,6 +12,7 @@ class TerraformConfigGenerator:
         os.makedirs('target', exist_ok=True)
 
     def generate_variables_tf_file(self):
+
         print("Generating variables.tf...")
         variables = [
             "snowflake_account",
@@ -35,6 +36,7 @@ class TerraformConfigGenerator:
         print("Generating variables.tf...done")
 
     def generate_providers_tf_file(self):
+
         print("Generating providers.tf...")
         config = textwrap.dedent("""\
         terraform {
@@ -61,6 +63,7 @@ class TerraformConfigGenerator:
         print("Generating providers.tf...done")
 
     def add_missing_environment_variables_to_tfvars_file(self):
+
         print("Generating terraform.tfvars...")
         variables = {
             "snowflake_account": "",
@@ -107,6 +110,7 @@ class TerraformConfigGenerator:
             f.write("\n" + config)
 
     def _generate_resource_config_for_all_databases(self):
+
         print("Querying Snowflake for all databases...")
         databases = self.connector.get_all_databases()
         print("Querying Snowflake for all databases...done")
@@ -119,14 +123,13 @@ class TerraformConfigGenerator:
                 "name": database['name'],
                 "properties": {
                     "name": database['name'],
-                    "comment": database['comment'],
-                    "data_retention_time_in_days": database['retention_time']
                 }
             }
             resources.append(resource)
         return resources
 
     def _generate_resource_config_for_all_roles(self):
+
         print("Querying Snowflake for all roles...")
         roles = self.connector.get_all_roles()
         print("Querying Snowflake for all roles...done")
@@ -139,13 +142,13 @@ class TerraformConfigGenerator:
                 "name": role['name'],
                 "properties": {
                     "name": role['name'],
-                    "comment": role['comment']
                 }
             }
             resources.append(resource)
         return resources
 
     def _generate_resource_config_for_all_users(self):
+
         print("Querying Snowflake for all users...")
         users = self.connector.get_all_users()
         print("Querying Snowflake for all users...done")
@@ -159,15 +162,6 @@ class TerraformConfigGenerator:
                 "properties": {
                     "name": user['name'],
                     "login_name": user['login_name'],
-                    "comment": user['comment'],
-                    "disabled": user['disabled'].lower(),
-                    "display_name": user['display_name'],
-                    "email": user['email'],
-                    "first_name": user['first_name'],
-                    "last_name": user['last_name'],
-                    "default_warehouse": user['default_warehouse'],
-                    "default_role": user['default_role'],
-                    "must_change_password": user['must_change_password'].lower(),
                 }
             }
             # If optional fields 'default_namespace' and 'default_secondary_roles' are present, add them to properties
@@ -186,6 +180,7 @@ class TerraformConfigGenerator:
 
 
     def _generate_resource_config_for_all_warehouses(self):
+
         print("Querying Snowflake for all warehouses...")
         warehouses = self.connector.get_all_warehouses()
         print("Querying Snowflake for all warehouses...done")
@@ -198,14 +193,6 @@ class TerraformConfigGenerator:
                 "name": warehouse['name'],
                 "properties": {
                     "name": warehouse['name'],
-                    "comment": warehouse['comment'],
-                    "warehouse_size": warehouse['size'],
-                    "auto_suspend": int(warehouse['auto_suspend']),
-                    "auto_resume": str(warehouse['auto_resume'].lower() == 'true').lower(),
-                "initially_suspended": str(warehouse['state'].upper() == 'SUSPENDED').lower(),
-                "scaling_policy": warehouse['scaling_policy'],
-                "min_cluster_count": int(warehouse['min_cluster_count']),
-                "max_cluster_count": int(warehouse['max_cluster_count'])
                 }
             }
             resources.append(resource)
@@ -241,6 +228,7 @@ class TerraformConfigGenerator:
         print("Running terraform init...done")
 
     def import_resources(self):
+
         # Delete existing .tfstate file if it exists
         tfstate_file_path = 'target/terraform.tfstate'
         if os.path.exists(tfstate_file_path):

--- a/snowglober/generate_tf_config.py
+++ b/snowglober/generate_tf_config.py
@@ -14,10 +14,10 @@ class TerraformConfigGenerator:
 
         # Define resources_to_generate as an instance attribute
         self.resources_to_generate = [
-            {"resource_type": "snowflake_database", "file_name": "databases", "generation_method": self._generate_resource_config_for_all_databases},
-            {"resource_type": "snowflake_role", "file_name": "roles", "generation_method": self._generate_resource_config_for_all_roles},
-            {"resource_type": "snowflake_user", "file_name": "users", "generation_method": self._generate_resource_config_for_all_users},
-            {"resource_type": "snowflake_warehouse", "file_name": "warehouses", "generation_method": self._generate_resource_config_for_all_warehouses},
+            {"resource_type": "snowflake_database", "generation_method": self._generate_resource_config_for_all_databases},
+            {"resource_type": "snowflake_role", "generation_method": self._generate_resource_config_for_all_roles},
+            {"resource_type": "snowflake_user", "generation_method": self._generate_resource_config_for_all_users},
+            {"resource_type": "snowflake_warehouse", "generation_method": self._generate_resource_config_for_all_warehouses},
         ]
 
     def generate_variables_tf_file(self):
@@ -235,17 +235,18 @@ class TerraformConfigGenerator:
         # Generate config for each resource type and write to file
         for resource_info in self.resources_to_generate:
             config = resource_info["generation_method"]()
+            resource_type = resource_info["resource_type"]
 
-            print(f'Generating config for {resource_info["file_name"]} at target/{resource_info["file_name"]}.tf...')
+            print(f'Generating config for {resource_type} at target/{resource_type}.tf...')
             
-            with open(f'target/{resource_info["file_name"]}.tf', 'w') as f:
+            with open(f'target/{resource_type}.tf', 'w') as f:
                 for resource in config:
                     f.write("resource \"{}\" \"{}\" {{\n".format(resource["type"], resource["name"]))
                     for property, value in resource["properties"].items():
                         f.write("    {} = \"{}\"\n".format(property, value))
                     f.write("}\n\n")
             
-            print(f'Generating config for {resource_info["file_name"]} at target/{resource_info["file_name"]}.tf...done')
+            print(f'Generating config for {resource_type} at target/{resource_type}.tf...done')
 
     def run_terraform_init(self):
 
@@ -307,10 +308,13 @@ class TerraformConfigGenerator:
 
         # Loop through each resource type
         for resource_info in self.resources_to_generate:
-            tf_file_path = f'target/{resource_info["file_name"]}.tf'
+            
+            resource_type = resource_info["resource_type"]
+
+            tf_file_path = f'target/{resource_type}.tf'
 
             if not os.path.exists(tf_file_path):
-                print(f'No .tf file found for {resource_info["file_name"]}. Skipping.')
+                print(f'No .tf file found for {resource_type}. Skipping.')
                 continue
 
             with open(tf_file_path, 'r') as f:

--- a/snowglober/generate_tf_config.py
+++ b/snowglober/generate_tf_config.py
@@ -178,6 +178,10 @@ class TerraformConfigGenerator:
 
         for user in users:
 
+            # Don't generate config for "SNOWFLAKE"; a user that's setup by Snowflake for accessing the system stats
+            if user['name'].upper() == 'SNOWFLAKE':
+                continue
+
             resource = {
                 "type": "snowflake_user",
                 "name": user['name'],

--- a/snowglober/main.py
+++ b/snowglober/main.py
@@ -4,6 +4,13 @@ from snowglober.snowflake_connector import SnowflakeConnector
 from generate_tf_config import TerraformConfigGenerator
 
 def main():
+    """
+    This function is the main entry point for the application.
+    It instantiates the SnowflakeConnector and TerraformConfigGenerator
+    classes, and then calls the methods to generate the Terraform configs.
+    It's also responsible for running the Terraform commands to import
+    the resources into the Terraform state.
+    """
     connector = SnowflakeConnector()
     generator = TerraformConfigGenerator(connector)
     generator.generate_variables_tf_file()

--- a/snowglober/main.py
+++ b/snowglober/main.py
@@ -10,6 +10,7 @@ def main():
     generator.generate_providers_tf_file()
     generator.add_missing_environment_variables_to_tfvars_file()
     generator.write_resource_configs_to_tf_files()
+    generator.import_resources()
 
 if __name__ == "__main__":
     main()

--- a/snowglober/main.py
+++ b/snowglober/main.py
@@ -12,6 +12,7 @@ def main():
     generator.write_resource_configs_to_tf_files()
     generator.run_terraform_init()
     generator.import_resources()
+    generator.update_tf_files_with_optional_properties()
 
 if __name__ == "__main__":
     main()

--- a/snowglober/main.py
+++ b/snowglober/main.py
@@ -10,6 +10,7 @@ def main():
     generator.generate_providers_tf_file()
     generator.add_missing_environment_variables_to_tfvars_file()
     generator.write_resource_configs_to_tf_files()
+    generator.run_terraform_init()
     generator.import_resources()
 
 if __name__ == "__main__":

--- a/snowglober/main.py
+++ b/snowglober/main.py
@@ -17,5 +17,3 @@ def main():
 if __name__ == "__main__":
     main()
     print("Snowglober has successfully finished generating Terraform configs!")
-
-

--- a/snowglober/snowflake_connector.py
+++ b/snowglober/snowflake_connector.py
@@ -47,30 +47,20 @@ class SnowflakeConnector:
         finally:
             cur.close()
 
-    def get_all_databases(self):
+    def get_all_objects_of_a_resource_type(self, entity):
         """
-        This method returns a list of all databases in Snowflake.
+        This method returns a list of all instances of the specified entity in Snowflake.
+        The entity should be one of: databases, roles, users, warehouses.
         """
-        query = "show databases"
-        return self._execute_query(query)
-    
-    def get_all_roles(self):
-        """
-        This method returns a list of all roles in Snowflake.
-        """
-        query = "show roles"
-        return self._execute_query(query)
+        valid_entities = [
+            'databases',
+            'roles',
+            'users',
+            'warehouses',
+            ]
 
-    def get_all_users(self):
-        """
-        This method returns a list of all users in Snowflake.
-        """
-        query = "show users"
-        return self._execute_query(query)
+        if entity not in valid_entities:
+            raise ValueError(f"Invalid entity '{entity}'. Choose one of {valid_entities}")
 
-    def get_all_warehouses(self):
-        """
-        This method returns a list of all warehouses in Snowflake.
-        """
-        query = "show warehouses"
+        query = f"show {entity}"
         return self._execute_query(query)

--- a/snowglober/snowflake_connector.py
+++ b/snowglober/snowflake_connector.py
@@ -6,6 +6,10 @@ from snowflake.connector import connect, DictCursor
 class SnowflakeConnector:
 
     def __init__(self):
+        """
+        This method initializes the SnowflakeConnector class and
+        loads the environment variables from the .env file.
+        """
         load_dotenv()
         self.user = os.getenv('SNOWFLAKE_USERNAME')
         self.password = os.getenv('SNOWFLAKE_PASSWORD')
@@ -17,7 +21,10 @@ class SnowflakeConnector:
         self.connection = self._connect()
 
     def _connect(self):
-        """Establishes a connection to Snowflake."""
+        """
+        This method establishes a connection to Snowflake using the
+        environment variables defined in the .env file.
+        """
         return connect(
             user=self.user,
             password=self.password,
@@ -29,6 +36,10 @@ class SnowflakeConnector:
         )
 
     def _execute_query(self, query):
+        """
+        This method executes a query against Snowflake and returns
+        the results.
+        """
         cur = self.connection.cursor(DictCursor)
         try:
             cur.execute(query)
@@ -37,17 +48,29 @@ class SnowflakeConnector:
             cur.close()
 
     def get_all_databases(self):
+        """
+        This method returns a list of all databases in Snowflake.
+        """
         query = "show databases"
         return self._execute_query(query)
     
     def get_all_roles(self):
+        """
+        This method returns a list of all roles in Snowflake.
+        """
         query = "show roles"
         return self._execute_query(query)
 
     def get_all_users(self):
+        """
+        This method returns a list of all users in Snowflake.
+        """
         query = "show users"
         return self._execute_query(query)
 
     def get_all_warehouses(self):
+        """
+        This method returns a list of all warehouses in Snowflake.
+        """
         query = "show warehouses"
         return self._execute_query(query)


### PR DESCRIPTION
## Description & motivation
JIRA issue: https://rittmananalytics.atlassian.net/browse/TS-12

This PR adds programmatic `terraform import` for each generated resource.

It changes the workflow to the following:
1. set up `provider` and `variable` files; **variables** contain **creds** and are populated from `.env` vars
1. query **snowflake** for all objects of each **resource type**  (currently limited to databases, roles, users and warehouses)
1. generate `.tf` files with **resources** - at this stage only required properties are defined
1. run `terraform init`
1. run `terraform import` for each resource
1. extract remaining (and optional) properties from the generated `.tfstate` file
1. update the **resources** in the `.tf` files with the remaining properties

## Detailed changes

added
* programmatic `terraform import` for each generated resource
* `terraform init` before `terraform import` commands
* architecture to README

changed
* removed non-essential properties from initial .tf generation
  * those properties are now taken from the .tfstate file after the `terraform import` commands
* added more completion print messages for usability
* added Docstrings for method readability
* combined resource type-specific methods into one to keep things DRY:
  * config generation `_generate_resource_config_for_all_objects_of_a_resource_type`
  * snowflake querying: `get_all_objects_of_a_resource_type`

## Checklist
- [x] My pull request represents one story (logical piece of work).
- [X] I have updated the version in `setup.py`.
- [X] I have re-read all docstrings and other documentation affected by my changes and ensured they are accurate.
- [X] I have added comments throughout my project that allow an understanding of what the code does without the need to read the code itself.
- [X] I have re-read the `README` and updated relevant sections that pertain to this PR.
- [X] My package has no residual code that is no longer used.